### PR TITLE
Update assoc-aggregate, king-ibdseg, and pc-relate via sbpack

### DIFF
--- a/association/assoc-aggregate-wf.cwl
+++ b/association/assoc-aggregate-wf.cwl
@@ -613,22 +613,22 @@ hints:
 - class: sbg:maxNumberOfParallelInstances
   value: '8'
 - class: sbg:AzureInstanceType
-  value: Standard_D8s_v4;StandardSSD;1024
+  value: Standard_D8s_v4;PremiumSSD;1024
 sbg:appVersion:
 - v1.2
 - v1.1
 sbg:categories:
 - GWAS
 - CWL1.0
-sbg:content_hash: ab28d9b5c570f33566a7bca935171b1011ceda973c55a941c3c0474975e0f51b5
+sbg:content_hash: a141fb71bddbf75140b16926ccab3479baf190f1cb9d94d82a5665360334584ec
 sbg:contributors:
 - admin
 sbg:createdBy: admin
 sbg:createdOn: 1577727846
 sbg:expand_workflow: false
-sbg:id: admin/sbg-public-data/aggregate-association-testing/27
+sbg:id: admin/sbg-public-data/aggregate-association-testing/30
 sbg:image_url:
-sbg:latestRevision: 27
+sbg:latestRevision: 30
 sbg:license: MIT
 sbg:links:
 - id: https://github.com/UW-GAC/analysis_pipeline
@@ -642,14 +642,14 @@ sbg:links:
 - id: https://bioconductor.org/packages/devel/bioc/manuals/GENESIS/man/GENESIS.pdf
   label: Documentation
 sbg:modifiedBy: admin
-sbg:modifiedOn: 1621514962
+sbg:modifiedOn: 1630939196
 sbg:original_source: |-
-  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/admin/sbg-public-data/aggregate-association-testing/27/raw/
+  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/admin/sbg-public-data/aggregate-association-testing/30/raw/
 sbg:project: admin/sbg-public-data
 sbg:projectName: SBG Public Data
 sbg:publisher: sbg
-sbg:revision: 27
-sbg:revisionNotes: Azure instance hint added
+sbg:revision: 30
+sbg:revisionNotes: chmod -R 777 added to command line
 sbg:revisionsInfo:
 - sbg:modifiedBy: admin
   sbg:modifiedOn: 1577727846
@@ -763,6 +763,18 @@ sbg:revisionsInfo:
   sbg:modifiedOn: 1621514962
   sbg:revision: 27
   sbg:revisionNotes: Azure instance hint added
+- sbg:modifiedBy: admin
+  sbg:modifiedOn: 1624463206
+  sbg:revision: 28
+  sbg:revisionNotes: Azure hint change
+- sbg:modifiedBy: admin
+  sbg:modifiedOn: 1624463206
+  sbg:revision: 29
+  sbg:revisionNotes: Azure hint change
+- sbg:modifiedBy: admin
+  sbg:modifiedOn: 1630939196
+  sbg:revision: 30
+  sbg:revisionNotes: chmod -R 777 added to command line
 sbg:sbgMaintained: false
 sbg:toolAuthor: TOPMed DCC
 sbg:validationErrors: []

--- a/association/tools/aggregate_list.cwl
+++ b/association/tools/aggregate_list.cwl
@@ -220,7 +220,7 @@ sbg:contributors:
 - boris_majic
 sbg:createdBy: boris_majic
 sbg:createdOn: 1577360995
-sbg:id: h-37bb3935/h-e1a85891/h-01de1637/0
+sbg:id: h-a57d0f6b/h-1a604d7b/h-f4ef086e/0
 sbg:image_url:
 sbg:latestRevision: 6
 sbg:modifiedBy: dajana_panovic

--- a/association/tools/assoc_aggregate.cwl
+++ b/association/tools/assoc_aggregate.cwl
@@ -325,7 +325,7 @@ sbg:contributors:
 - boris_majic
 sbg:createdBy: boris_majic
 sbg:createdOn: 1577360633
-sbg:id: h-504831e9/h-24d85432/h-179e7c35/0
+sbg:id: h-2cd01937/h-3a1dba4d/h-b6926954/0
 sbg:image_url:
 sbg:latestRevision: 7
 sbg:modifiedBy: dajana_panovic

--- a/association/tools/assoc_combine_r.cwl
+++ b/association/tools/assoc_combine_r.cwl
@@ -204,7 +204,7 @@ sbg:contributors:
 - boris_majic
 sbg:createdBy: boris_majic
 sbg:createdOn: 1577360839
-sbg:id: h-6b1a5e94/h-48643949/h-a6d2c5ff/0
+sbg:id: h-d69710eb/h-2f8161fe/h-fd7b8e6d/0
 sbg:image_url:
 sbg:latestRevision: 7
 sbg:modifiedBy: dajana_panovic

--- a/association/tools/assoc_plots_r.cwl
+++ b/association/tools/assoc_plots_r.cwl
@@ -334,26 +334,28 @@ arguments:
 hints:
 - class: sbg:SaveLogs
   value: job.out.log
-id: boris_majic/genesis-toolkit-demo/assoc-plots-r/20
+- class: sbg:AzureInstanceType
+  value: Standard_D8s_v4;PremiumSSD;512
+id: boris_majic/genesis-toolkit-demo/assoc-plots-r/21
 sbg:appVersion:
 - v1.2
-sbg:content_hash: a82da30efa86852cf30f8281fb890d35b617b19188930e4ef3028caeededad0d3
+sbg:content_hash: ac69853666a83b66464719ab99d0f3422d6986b55831a7556e56b6d8311c6d61b
 sbg:contributors:
+- milan.domazet
 - dajana_panovic
 - boris_majic
-- milan.domazet
 sbg:createdBy: boris_majic
 sbg:createdOn: 1577360892
-sbg:id: h-8479d2e5/h-9146a23b/h-deedbeef/0
+sbg:id: h-7f8e6efa/h-f73afcf8/h-7b7e3fe1/0
 sbg:image_url:
-sbg:latestRevision: 20
+sbg:latestRevision: 21
 sbg:modifiedBy: dajana_panovic
-sbg:modifiedOn: 1620727319
+sbg:modifiedOn: 1622800608
 sbg:project: boris_majic/genesis-toolkit-demo
 sbg:projectName: GENESIS Toolkit - DEMO
 sbg:publisher: sbg
-sbg:revision: 20
-sbg:revisionNotes: Labels update
+sbg:revision: 21
+sbg:revisionNotes: Azure instance type
 sbg:revisionsInfo:
 - sbg:modifiedBy: boris_majic
   sbg:modifiedOn: 1577360892
@@ -439,5 +441,9 @@ sbg:revisionsInfo:
   sbg:modifiedOn: 1620727319
   sbg:revision: 20
   sbg:revisionNotes: Labels update
+- sbg:modifiedBy: dajana_panovic
+  sbg:modifiedOn: 1622800608
+  sbg:revision: 21
+  sbg:revisionNotes: Azure instance type
 sbg:sbgMaintained: false
 sbg:validationErrors: []

--- a/association/tools/define_segments_r.cwl
+++ b/association/tools/define_segments_r.cwl
@@ -105,7 +105,7 @@ sbg:contributors:
 - boris_majic
 sbg:createdBy: boris_majic
 sbg:createdOn: 1577360777
-sbg:id: h-694d1b5f/h-1a5343c2/h-bf2a9372/0
+sbg:id: h-02a60c39/h-39cedd71/h-c37ccd0f/0
 sbg:image_url:
 sbg:latestRevision: 6
 sbg:modifiedBy: dajana_panovic

--- a/association/tools/sbg_flatten_lists.cwl
+++ b/association/tools/sbg_flatten_lists.cwl
@@ -194,7 +194,7 @@ sbg:contributors:
 - nens
 sbg:createdBy: nens
 sbg:createdOn: 1566552375
-sbg:id: h-7cd6fb73/h-5d673563/h-96acf002/0
+sbg:id: h-51890b6f/h-d69783f7/h-9b354172/0
 sbg:image_url:
 sbg:latestRevision: 3
 sbg:license: Apache License 2.0

--- a/association/tools/sbg_gds_renamer.cwl
+++ b/association/tools/sbg_gds_renamer.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.1
+cwlVersion: v1.2
 class: CommandLineTool
 label: SBG GDS renamer
 doc: |-
@@ -10,7 +10,7 @@ $namespaces:
 requirements:
 - class: ShellCommandRequirement
 - class: DockerRequirement
-  dockerPull: uwgac/topmed-master:2.8.1
+  dockerPull: uwgac/topmed-master:2.10.0
 - class: InlineJavascriptRequirement
 
 inputs:
@@ -70,30 +70,30 @@ arguments:
   shellQuote: false
 - prefix: ''
   position: 100
-  valueFrom: "${\n    return ' >> job.out.log'   \n}"
+  valueFrom: "${\n    return ' >> job.out.log && chmod -R 777 .' \n}"
   shellQuote: false
 
 hints:
 - class: sbg:SaveLogs
   value: job.out.log
-id: sevenbridges/sbgtools-cwl1-0-demo/sbg-gds-renamer/3
+id: sevenbridges/sbgtools-cwl1-0-demo/sbg-gds-renamer/4
 sbg:appVersion:
-- v1.1
-sbg:content_hash: ab721cbd39c33d272c5c42693fb02e02e43d95a3f421f40615cbf79ed023c35cc
+- v1.2
+sbg:content_hash: aab167dd7a4bb3a5384595723197895ae486fdb06edfd1f4c39eec2299eced6c5
 sbg:contributors:
 - dajana_panovic
 sbg:createdBy: dajana_panovic
 sbg:createdOn: 1584358811
-sbg:id: h-dab060b5/h-741a14f7/h-284eaa42/0
+sbg:id: h-d0193c1c/h-fe125092/h-f48c3efc/0
 sbg:image_url:
-sbg:latestRevision: 3
+sbg:latestRevision: 4
 sbg:modifiedBy: dajana_panovic
-sbg:modifiedOn: 1608907259
+sbg:modifiedOn: 1630916163
 sbg:project: sevenbridges/sbgtools-cwl1-0-demo
-sbg:projectName: SBGTools - CWL1.0 - Demo
+sbg:projectName: SBGTools - CWL1.x - Demo
 sbg:publisher: sbg
-sbg:revision: 3
-sbg:revisionNotes: CWLtool prep
+sbg:revision: 4
+sbg:revisionNotes: chmod -R 777 added to command line
 sbg:revisionsInfo:
 - sbg:modifiedBy: dajana_panovic
   sbg:modifiedOn: 1584358811
@@ -111,5 +111,9 @@ sbg:revisionsInfo:
   sbg:modifiedOn: 1608907259
   sbg:revision: 3
   sbg:revisionNotes: CWLtool prep
+- sbg:modifiedBy: dajana_panovic
+  sbg:modifiedOn: 1630916163
+  sbg:revision: 4
+  sbg:revisionNotes: chmod -R 777 added to command line
 sbg:sbgMaintained: false
 sbg:validationErrors: []

--- a/association/tools/sbg_group_segments_1.cwl
+++ b/association/tools/sbg_group_segments_1.cwl
@@ -126,7 +126,7 @@ sbg:contributors:
 - dajana_panovic
 sbg:createdBy: dajana_panovic
 sbg:createdOn: 1608907549
-sbg:id: h-e8014352/h-5efb56fe/h-a154a81a/0
+sbg:id: h-5bd2b83b/h-435f591a/h-e047dd70/0
 sbg:image_url:
 sbg:latestRevision: 1
 sbg:modifiedBy: dajana_panovic

--- a/association/tools/sbg_prepare_segments_1.cwl
+++ b/association/tools/sbg_prepare_segments_1.cwl
@@ -314,7 +314,7 @@ sbg:contributors:
 - dajana_panovic
 sbg:createdBy: dajana_panovic
 sbg:createdOn: 1608907510
-sbg:id: h-ae747e88/h-9feb5ac4/h-9ff1f472/0
+sbg:id: h-c606ebab/h-b0278e7b/h-ce2bda1f/0
 sbg:image_url:
 sbg:latestRevision: 1
 sbg:modifiedBy: dajana_panovic

--- a/relatedness/king-ibdseg-wf.cwl
+++ b/relatedness/king-ibdseg-wf.cwl
@@ -9,6 +9,7 @@ $namespaces:
 requirements:
 - class: InlineJavascriptRequirement
 - class: StepInputExpressionRequirement
+- class: SubworkflowFeatureRequirement
 
 inputs:
 - id: gds_file
@@ -30,47 +31,61 @@ inputs:
   label: Variant Include file
   doc: |-
     RData file with vector of variant.id to use for kinship estimation. If not provided, all variants in the GDS file are included.
-  type: File?
+  type:
+  - 'null'
+  - File
   sbg:fileTypes: RDATA
   sbg:x: -553.8265380859375
   sbg:y: -59.5318489074707
 - id: out_prefix
   label: Output prefix
   doc: Prefix for output files.
-  type: string?
+  type:
+  - 'null'
+  - string
   sbg:x: -428.742919921875
   sbg:y: -223.19976806640625
 - id: phenotype_file
   label: Phenotype File
   doc: |-
     RData file with data.frame or AnnotatedDataFrame of phenotypes. Used for plotting kinship estimates separately by group.
-  type: File?
+  type:
+  - 'null'
+  - File
   sbg:fileTypes: RDATA
   sbg:x: 128.62420654296875
   sbg:y: -225.0599365234375
 - id: kinship_plot_threshold
   label: Kinship plotting threshold
   doc: Minimum kinship for a pair to be included in the plot.
-  type: float?
+  type:
+  - 'null'
+  - float
   sbg:exposed: true
   sbg:toolDefaultValue: 2^(-9/2) (third-degree relatives and closer)
 - id: group
   label: Group column name
   doc: |-
     Name of column in phenotype_file containing group variable (e.g., study) for plotting.
-  type: string?
+  type:
+  - 'null'
+  - string
   sbg:exposed: true
 - id: sparse_threshold
   label: Sparse threshold
   doc: |-
     Threshold for making the output kinship matrix sparse. A block diagonal matrix will be created such that any pair of samples with a kinship estimate greater than the threshold is in the same block; all pairwise estimates within a block are kept, and pairwise estimates between blocks are set to 0.
-  type: float?
+  type:
+  - 'null'
+  - float
   sbg:exposed: true
   sbg:toolDefaultValue: 2^(-11/2) (~0.022, 4th degree)
 - id: cpu
   label: Number of CPUs
   doc: Number of CPUs to use.
-  type: int?
+  type:
+  - 'null'
+  - int
   sbg:exposed: true
   sbg:toolDefaultValue: '4'
 
@@ -79,7 +94,9 @@ outputs:
   label: Kinship matrix
   doc: |-
     A block-diagonal matrix of pairwise kinship estimates. Samples are clustered into blocks of relatives based on `sparse_threshold`; all kinship estimates within a block are kept, and kinship estimates between blocks are set to 0. When `sparse_threshold` is 0, all kinship estimates are included in the output matrix.
-  type: File?
+  type:
+  - 'null'
+  - File
   outputSource:
   - king_to_matrix/king_matrix
   sbg:fileTypes: RDATA
@@ -89,7 +106,10 @@ outputs:
   label: Kinship plots
   doc: |-
     Hexbin plots of estimated kinship coefficients vs. IBS0. If "group" is provided, additional plots will be generated within each group and across groups.
-  type: File[]?
+  type:
+  - 'null'
+  - type: array
+    items: File
   outputSource:
   - kinship_plots/kinship_plots
   sbg:fileTypes: PDF
@@ -198,159 +218,60 @@ sbg:appVersion:
 sbg:categories:
 - GWAS
 - Ancestry and Relatedness
-sbg:content_hash: ac4421e0278f471efcc695bb067a2d910adb245932183f934be9e9e44598613dd
+sbg:content_hash: ad64aaa912ab534ec514805924f93338746245cab21499da126957b4c73e63d21
 sbg:contributors:
 - smgogarten
 sbg:createdBy: smgogarten
-sbg:createdOn: 1583955734
-sbg:id: smgogarten/genesis-relatedness/king-pipeline/31
-sbg:image_url:
-sbg:latestRevision: 31
+sbg:createdOn: 1609462902
+sbg:id: smgogarten/uw-gac-commit/king-ibdseg/4
+sbg:image_url: |-
+  https://platform.sb.biodatacatalyst.nhlbi.nih.gov/ns/brood/images/smgogarten/uw-gac-commit/king-ibdseg/4.png
+sbg:latestRevision: 4
 sbg:modifiedBy: smgogarten
-sbg:modifiedOn: 1623276406
+sbg:modifiedOn: 1629513179
 sbg:original_source: |-
-  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/genesis-relatedness/king-pipeline/31/raw/
-sbg:project: smgogarten/genesis-relatedness
-sbg:projectName: GENESIS relatedness
-sbg:publisher: sbg
-sbg:revision: 31
-sbg:revisionNotes: add ibdseg string to matrix output filename
+  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/uw-gac-commit/king-ibdseg/4/raw/
+sbg:project: smgogarten/uw-gac-commit
+sbg:projectName: UW GAC - Commit
+sbg:publisher: UWGAC
+sbg:revision: 4
+sbg:revisionNotes: |-
+  Uploaded using sbpack v2020.10.05. 
+  Source: 
+  repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+  file: relatedness/king-ibdseg-wf.cwl
+  commit: f23d6de
 sbg:revisionsInfo:
 - sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1583955734
+  sbg:modifiedOn: 1609462902
   sbg:revision: 0
-  sbg:revisionNotes: Copy of boris_majic/topmed-optimization/king-pipeline/2
+  sbg:revisionNotes:
 - sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1588634638
+  sbg:modifiedOn: 1609462933
   sbg:revision: 1
-  sbg:revisionNotes: remove king_related, only run king_ibdseg
+  sbg:revisionNotes: import from pre-build project
 - sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1588807142
+  sbg:modifiedOn: 1612396152
   sbg:revision: 2
-  sbg:revisionNotes: revise inputs and outputs
+  sbg:revisionNotes: add categories and toolkit
 - sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1601930483
+  sbg:modifiedOn: 1623797846
   sbg:revision: 3
-  sbg:revisionNotes: new version of gds2bed
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1601944311
-  sbg:revision: 4
-  sbg:revisionNotes: new version of plink_make-bed
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1601964691
-  sbg:revision: 5
-  sbg:revisionNotes: updated plink_make-bed
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1603229838
-  sbg:revision: 6
-  sbg:revisionNotes: use current tools from this project
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1603254161
-  sbg:revision: 7
-  sbg:revisionNotes: use revised plink_make_bed with suffix
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1603479524
-  sbg:revision: 8
-  sbg:revisionNotes: new tool versions, output prefix
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1603485667
-  sbg:revision: 9
-  sbg:revisionNotes: fix .seg output mapping
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1603491626
-  sbg:revision: 10
-  sbg:revisionNotes: add phenotype file as an input
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1604986255
-  sbg:revision: 11
-  sbg:revisionNotes: add suffixes to output_prefix, include ibdseg results in workflow
-    output
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1605577182
-  sbg:revision: 12
-  sbg:revisionNotes: update all tools
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1608074003
-  sbg:revision: 13
-  sbg:revisionNotes: update descriptions
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1608600161
-  sbg:revision: 14
-  sbg:revisionNotes: add app description
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1608619419
-  sbg:revision: 15
-  sbg:revisionNotes: expose threshold for plotting kinship
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609311199
-  sbg:revision: 16
-  sbg:revisionNotes: update descriptions
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609311243
-  sbg:revision: 17
-  sbg:revisionNotes: remove _1 suffix for steps
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609311494
-  sbg:revision: 18
-  sbg:revisionNotes: set defaults
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609311762
-  sbg:revision: 19
-  sbg:revisionNotes: add _1 suffix to kinship_plots to address "workflow contains
-    a cycle"
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609312623
-  sbg:revision: 20
-  sbg:revisionNotes: updated tool
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609367777
-  sbg:revision: 21
-  sbg:revisionNotes: update descriptions
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609367832
-  sbg:revision: 22
-  sbg:revisionNotes: fix broken connection
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609371288
-  sbg:revision: 23
-  sbg:revisionNotes: expose plotting parameters
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609371562
-  sbg:revision: 24
-  sbg:revisionNotes: show tool default
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609374452
-  sbg:revision: 25
-  sbg:revisionNotes: update descriptions
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609449636
-  sbg:revision: 26
-  sbg:revisionNotes: update descriptions
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609450034
-  sbg:revision: 27
-  sbg:revisionNotes: update descriptions
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1615934680
-  sbg:revision: 28
   sbg:revisionNotes: |-
     Uploaded using sbpack v2020.10.05. 
     Source: 
     repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
-    file: 
-    commit: (uncommitted file)
+    file: relatedness/king-ibdseg-wf.cwl
+    commit: bc68069
 - sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1623274735
-  sbg:revision: 29
-  sbg:revisionNotes: update tools and label descriptions
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1623276248
-  sbg:revision: 30
-  sbg:revisionNotes: add king_ibdseg string to output plot filename
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1623276406
-  sbg:revision: 31
-  sbg:revisionNotes: add ibdseg string to matrix output filename
+  sbg:modifiedOn: 1629513179
+  sbg:revision: 4
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: relatedness/king-ibdseg-wf.cwl
+    commit: f23d6de
 sbg:sbgMaintained: false
 sbg:toolkit: UW-GAC Ancestry and Relatedness
 sbg:validationErrors: []

--- a/relatedness/pc-relate-wf.cwl
+++ b/relatedness/pc-relate-wf.cwl
@@ -10,6 +10,7 @@ requirements:
 - class: ScatterFeatureRequirement
 - class: InlineJavascriptRequirement
 - class: StepInputExpressionRequirement
+- class: SubworkflowFeatureRequirement
 
 inputs:
 - id: pca_file
@@ -31,7 +32,9 @@ inputs:
   label: Sample Include file
   doc: |-
     RData file with vector of sample.id to include. If not provided, all samples in the GDS file are included.
-  type: File?
+  type:
+  - 'null'
+  - File
   sbg:fileTypes: RDATA
   sbg:x: -175.52853393554688
   sbg:y: -72.8362808227539
@@ -39,7 +42,9 @@ inputs:
   label: Number of PCs
   doc: |-
     Number of PCs (Principal Components) in `pca_file` to use in adjusting for ancestry.
-  type: int?
+  type:
+  - 'null'
+  - int
   sbg:toolDefaultValue: '3'
   sbg:x: -61.75441360473633
   sbg:y: 284.0424499511719
@@ -47,28 +52,36 @@ inputs:
   label: Variant include file
   doc: |-
     RData file with vector of variant.id to include. If not provided, all variants in the GDS file are included.
-  type: File?
+  type:
+  - 'null'
+  - File
   sbg:fileTypes: RDATA
   sbg:x: -169.77308654785156
   sbg:y: -226.9329071044922
 - id: variant_block_size
   label: Variant block size
   doc: Number of variants to read in a single block.
-  type: int?
+  type:
+  - 'null'
+  - int
   sbg:toolDefaultValue: '1024'
   sbg:x: -60.2248649597168
   sbg:y: -132.0818634033203
 - id: out_prefix
   label: Output prefix
   doc: Prefix for output files.
-  type: string?
+  type:
+  - 'null'
+  - string
   sbg:x: -65.81759643554688
   sbg:y: 105.9605941772461
 - id: n_sample_blocks
   label: Number of sample blocks
   doc: |-
     Number of blocks to divide samples into for parallel computation. Adjust depending on computer memory and number of samples in the analysis.
-  type: int?
+  type:
+  - 'null'
+  - int
   sbg:toolDefaultValue: '1'
   sbg:x: 49.20663070678711
   sbg:y: -341.2738037109375
@@ -76,34 +89,44 @@ inputs:
   label: Phenotype File
   doc: |-
     RData file with data.frame or AnnotatedDataFrame of phenotypes. Used for plotting kinship estimates separately by group.
-  type: File?
+  type:
+  - 'null'
+  - File
   sbg:fileTypes: RDATA
   sbg:x: 645.658203125
   sbg:y: 169.88719177246094
 - id: kinship_plot_threshold
   label: Kinship plotting threshold
   doc: Minimum kinship for a pair to be included in the plot.
-  type: float?
+  type:
+  - 'null'
+  - float
   sbg:exposed: true
   sbg:toolDefaultValue: 2^(-9/2) (third-degree relatives and closer)
 - id: group
   label: Group column name
   doc: |-
     Name of column in phenotype_file containing group variable (e.g., study) for plotting.
-  type: string?
+  type:
+  - 'null'
+  - string
   sbg:exposed: true
 - id: sparse_threshold
   label: Sparse threshold
   doc: |-
     Threshold for making the output kinship matrix sparse. A block diagonal matrix will be created such that any pair of samples with a kinship estimate greater than the threshold is in the same block; all pairwise estimates within a block are kept, and pairwise estimates between blocks are set to 0.
-  type: float?
+  type:
+  - 'null'
+  - float
   sbg:exposed: true
   sbg:toolDefaultValue: 2^(-11/2) (~0.022, 4th degree)
 - id: ibd_probs
   label: Return IBD probabilities?
   doc: |-
     Set this to FALSE to skip computing pairwise IBD probabilities (k0, k1, k2). If FALSE, the plottng step is also skipped, as it requires values for k0.
-  type: boolean?
+  type:
+  - 'null'
+  - boolean
   default: true
   sbg:x: 210.16744995117188
   sbg:y: 258.3512268066406
@@ -113,7 +136,10 @@ outputs:
   label: Kinship plots
   doc: |-
     Hexbin plots of estimated kinship coefficients vs. IBS0. If "group" is provided, additional plots will be generated within each group and across groups.
-  type: File[]?
+  type:
+  - 'null'
+  - type: array
+    items: File
   outputSource:
   - kinship_plots/kinship_plots
   sbg:fileTypes: PDF
@@ -122,7 +148,9 @@ outputs:
 - id: pcrelate_output
   label: PC-Relate output file
   doc: PC-Relate output file with all samples
-  type: File?
+  type:
+  - 'null'
+  - File
   outputSource:
   - pcrelate_correct/pcrelate_output
   sbg:fileTypes: RDATA
@@ -132,7 +160,9 @@ outputs:
   label: Kinship matrix
   doc: |-
     A block diagonal matrix of pairwise kinship estimates with sparsity set by sparse_threshold. Samples are clustered into blocks of relatives based on `sparse_threshold`; all kinship estimates within a block are kept, and kinship estimates between blocks are set to 0. When `sparse_threshold` is 0, this is a dense matrix with all pairwise kinship estimates.
-  type: File?
+  type:
+  - 'null'
+  - File
   outputSource:
   - pcrelate_correct/pcrelate_matrix
   sbg:fileTypes: RDATA
@@ -251,101 +281,60 @@ sbg:appVersion:
 sbg:categories:
 - GWAS
 - Ancestry and Relatedness
-sbg:content_hash: a3c667ce3218bb0953c72b46e0c5f4fe40ba00b29c413bd2082d4086b51201ca4
+sbg:content_hash: ab1baee9b749fe1f706dc3ccb7f02c0a6dcf00eddf8f8f431b52ac9b2a74d26e6
 sbg:contributors:
 - smgogarten
 sbg:createdBy: smgogarten
-sbg:createdOn: 1583955838
-sbg:id: smgogarten/genesis-relatedness/pc-relate/17
-sbg:image_url:
-sbg:latestRevision: 17
+sbg:createdOn: 1609464055
+sbg:id: smgogarten/uw-gac-commit/pc-relate/4
+sbg:image_url: |-
+  https://platform.sb.biodatacatalyst.nhlbi.nih.gov/ns/brood/images/smgogarten/uw-gac-commit/pc-relate/4.png
+sbg:latestRevision: 4
 sbg:modifiedBy: smgogarten
-sbg:modifiedOn: 1623719892
+sbg:modifiedOn: 1629513252
 sbg:original_source: |-
-  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/genesis-relatedness/pc-relate/17/raw/
-sbg:project: smgogarten/genesis-relatedness
-sbg:projectName: GENESIS relatedness
-sbg:publisher: sbg
-sbg:revision: 17
-sbg:revisionNotes: set default values
+  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/uw-gac-commit/pc-relate/4/raw/
+sbg:project: smgogarten/uw-gac-commit
+sbg:projectName: UW GAC - Commit
+sbg:publisher: UWGAC
+sbg:revision: 4
+sbg:revisionNotes: |-
+  Uploaded using sbpack v2020.10.05. 
+  Source: 
+  repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+  file: relatedness/pc-relate-wf.cwl
+  commit: f23d6de
 sbg:revisionsInfo:
 - sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1583955838
+  sbg:modifiedOn: 1609464055
   sbg:revision: 0
-  sbg:revisionNotes: Copy of boris_majic/topmed-optimization/pc-relate/0
+  sbg:revisionNotes:
 - sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1606800131
+  sbg:modifiedOn: 1609464095
   sbg:revision: 1
-  sbg:revisionNotes: new version of pcrelate
+  sbg:revisionNotes: import from pre-build project
 - sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1606801398
+  sbg:modifiedOn: 1612396239
   sbg:revision: 2
-  sbg:revisionNotes: calculate segments from number of sample blocks
+  sbg:revisionNotes: add categories and toolkit
 - sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1606840751
+  sbg:modifiedOn: 1623797726
   sbg:revision: 3
-  sbg:revisionNotes: update tool versions
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1606844136
-  sbg:revision: 4
-  sbg:revisionNotes: segments must be an array for scattering
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1606936665
-  sbg:revision: 5
-  sbg:revisionNotes: use a separate tool to convert number of sample blocks to segments
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1606939082
-  sbg:revision: 6
-  sbg:revisionNotes: update tools to match filenames between pcrelate and pcrelate_correct
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1608667423
-  sbg:revision: 7
-  sbg:revisionNotes: update descriptions and defaults
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1608669249
-  sbg:revision: 8
-  sbg:revisionNotes: update App description
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1608745959
-  sbg:revision: 9
-  sbg:revisionNotes: fix order of workflow steps
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609374329
-  sbg:revision: 10
-  sbg:revisionNotes: update descriptions
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609374574
-  sbg:revision: 11
-  sbg:revisionNotes: fix broken link
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1609450276
-  sbg:revision: 12
-  sbg:revisionNotes: update descriptions
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1615937265
-  sbg:revision: 13
   sbg:revisionNotes: |-
     Uploaded using sbpack v2020.10.05. 
     Source: 
     repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
-    file: 
-    commit: (uncommitted file)
+    file: relatedness/pc-relate-wf.cwl
+    commit: 878efb2
 - sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1623277399
-  sbg:revision: 14
-  sbg:revisionNotes: update tools, add pcrelate string to plot filenames
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1623712754
-  sbg:revision: 15
-  sbg:revisionNotes: fix value transform for plot output filenames
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1623718256
-  sbg:revision: 16
-  sbg:revisionNotes: add option to skip IBD probs and plotting
-- sbg:modifiedBy: smgogarten
-  sbg:modifiedOn: 1623719892
-  sbg:revision: 17
-  sbg:revisionNotes: set default values
+  sbg:modifiedOn: 1629513252
+  sbg:revision: 4
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: relatedness/pc-relate-wf.cwl
+    commit: f23d6de
 sbg:sbgMaintained: false
 sbg:toolkit: UW-GAC Ancestry and Relatedness
 sbg:validationErrors: []

--- a/relatedness/tools/gds2bed.cwl
+++ b/relatedness/tools/gds2bed.cwl
@@ -103,3 +103,65 @@ hints:
   value: job.out.log
 - class: sbg:SaveLogs
   value: gds2bed.config
+id: |-
+  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/genesis-relatedness-pre-build/gds2bed/4/raw/
+sbg:appVersion:
+- v1.2
+sbg:content_hash: a3fae5d47ec40471588fecbda09301b3cf9d55d22822cc7dc09d339c7b9e3ae78
+sbg:contributors:
+- smgogarten
+sbg:createdBy: smgogarten
+sbg:createdOn: 1609451033
+sbg:id: smgogarten/genesis-relatedness-pre-build/gds2bed/4
+sbg:image_url:
+sbg:latestRevision: 4
+sbg:modifiedBy: smgogarten
+sbg:modifiedOn: 1623450740
+sbg:project: smgogarten/genesis-relatedness-pre-build
+sbg:projectName: GENESIS relatedness - Pre-build
+sbg:publisher: sbg
+sbg:revision: 4
+sbg:revisionNotes: |-
+  Uploaded using sbpack v2020.10.05. 
+  Source: 
+  repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+  file: 
+  commit: c9c8b8d
+sbg:revisionsInfo:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451033
+  sbg:revision: 0
+  sbg:revisionNotes:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451062
+  sbg:revision: 1
+  sbg:revisionNotes: import to pre-build project
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623444722
+  sbg:revision: 2
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623445036
+  sbg:revision: 3
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623450740
+  sbg:revision: 4
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+sbg:sbgMaintained: false
+sbg:validationErrors: []

--- a/relatedness/tools/king_ibdseg.cwl
+++ b/relatedness/tools/king_ibdseg.cwl
@@ -42,7 +42,9 @@ inputs:
 - id: cpu
   label: Number of CPUs
   doc: Number of CPUs to use.
-  type: int?
+  type:
+  - 'null'
+  - int
   default: 4
   inputBinding:
     prefix: --cpus
@@ -52,7 +54,9 @@ inputs:
 - id: out_prefix
   label: Output prefix
   doc: Prefix for output files.
-  type: string?
+  type:
+  - 'null'
+  - string
   inputBinding:
     prefix: --prefix
     position: 5
@@ -93,3 +97,65 @@ baseCommand:
 hints:
 - class: sbg:SaveLogs
   value: job.out.log
+id: |-
+  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/genesis-relatedness-pre-build/king-ibdseg/4/raw/
+sbg:appVersion:
+- v1.2
+sbg:content_hash: af4e54ea60112079238f41d4aad7712f302851f67c82bfa0b313f6ea5660e23d5
+sbg:contributors:
+- smgogarten
+sbg:createdBy: smgogarten
+sbg:createdOn: 1609451092
+sbg:id: smgogarten/genesis-relatedness-pre-build/king-ibdseg/4
+sbg:image_url:
+sbg:latestRevision: 4
+sbg:modifiedBy: smgogarten
+sbg:modifiedOn: 1623450742
+sbg:project: smgogarten/genesis-relatedness-pre-build
+sbg:projectName: GENESIS relatedness - Pre-build
+sbg:publisher: sbg
+sbg:revision: 4
+sbg:revisionNotes: |-
+  Uploaded using sbpack v2020.10.05. 
+  Source: 
+  repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+  file: 
+  commit: c9c8b8d
+sbg:revisionsInfo:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451092
+  sbg:revision: 0
+  sbg:revisionNotes:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451124
+  sbg:revision: 1
+  sbg:revisionNotes: import to pre-build project
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623444724
+  sbg:revision: 2
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623445039
+  sbg:revision: 3
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623450742
+  sbg:revision: 4
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+sbg:sbgMaintained: false
+sbg:validationErrors: []

--- a/relatedness/tools/king_to_matrix.cwl
+++ b/relatedness/tools/king_to_matrix.cwl
@@ -162,3 +162,65 @@ hints:
   value: job.out.log
 - class: sbg:SaveLogs
   value: king_to_matrix.config
+id: |-
+  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/genesis-relatedness-pre-build/king-to-matrix/4/raw/
+sbg:appVersion:
+- v1.2
+sbg:content_hash: aea95a431b122216fc3721cd1745b2c393f83fd6ac206e7491f05bb487d07781f
+sbg:contributors:
+- smgogarten
+sbg:createdBy: smgogarten
+sbg:createdOn: 1609451229
+sbg:id: smgogarten/genesis-relatedness-pre-build/king-to-matrix/4
+sbg:image_url:
+sbg:latestRevision: 4
+sbg:modifiedBy: smgogarten
+sbg:modifiedOn: 1623450743
+sbg:project: smgogarten/genesis-relatedness-pre-build
+sbg:projectName: GENESIS relatedness - Pre-build
+sbg:publisher: sbg
+sbg:revision: 4
+sbg:revisionNotes: |-
+  Uploaded using sbpack v2020.10.05. 
+  Source: 
+  repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+  file: 
+  commit: c9c8b8d
+sbg:revisionsInfo:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451229
+  sbg:revision: 0
+  sbg:revisionNotes:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451268
+  sbg:revision: 1
+  sbg:revisionNotes: import to pre-build project
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623444725
+  sbg:revision: 2
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623445040
+  sbg:revision: 3
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623450743
+  sbg:revision: 4
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+sbg:sbgMaintained: false
+sbg:validationErrors: []

--- a/relatedness/tools/kinship_plots.cwl
+++ b/relatedness/tools/kinship_plots.cwl
@@ -70,33 +70,43 @@ inputs:
 - id: kinship_plot_threshold
   label: Kinship plotting threshold
   doc: Minimum kinship for a pair to be included in the plot.
-  type: float?
+  type:
+  - 'null'
+  - float
   sbg:category: Input Options
   sbg:toolDefaultValue: 2^(-9/2) (third-degree relatives and closer)
 - id: phenotype_file
   label: Phenotype File
   doc: |-
     RData file with data.frame or AnnotatedDataFrame of phenotypes. Used for plotting kinship estimates separately by group.
-  type: File?
+  type:
+  - 'null'
+  - File
   sbg:category: Input Files
   sbg:fileTypes: RDATA
 - id: group
   label: Group column name
   doc: |-
     Name of column in phenotype_file containing group variable (e.g., study) for plotting.
-  type: string?
+  type:
+  - 'null'
+  - string
   sbg:category: Input Options
   sbg:toolDefaultValue: NA
 - id: sample_include_file
   label: Sample Include File
   doc: RData file with vector of sample.id to include.
-  type: File?
+  type:
+  - 'null'
+  - File
   sbg:category: Input Options
   sbg:fileTypes: RDATA
 - id: out_prefix
   label: Output prefix
   doc: Prefix for output files.
-  type: string?
+  type:
+  - 'null'
+  - string
   sbg:category: Input Options
   sbg:toolDefaultValue: kinship
 
@@ -105,7 +115,10 @@ outputs:
   label: Kinship plots
   doc: |-
     Hexbin plots of estimated kinship coefficients vs. IBS0. If "group" is provided, additional plots will be generated within each group and across groups.
-  type: File[]?
+  type:
+  - 'null'
+  - type: array
+    items: File
   outputBinding:
     glob: '*.pdf'
   sbg:fileTypes: PDF
@@ -128,3 +141,92 @@ hints:
   value: job.out.log
 - class: sbg:SaveLogs
   value: kinship_plots.config
+id: |-
+  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/genesis-relatedness-pre-build/kinship-plots/7/raw/
+sbg:appVersion:
+- v1.2
+sbg:content_hash: afdca9f28af72e0a3908f19de3855accf3bc03e7b0c3a886439605c004c137276
+sbg:contributors:
+- smgogarten
+sbg:createdBy: smgogarten
+sbg:createdOn: 1609451320
+sbg:id: smgogarten/genesis-relatedness-pre-build/kinship-plots/7
+sbg:image_url:
+sbg:latestRevision: 7
+sbg:modifiedBy: smgogarten
+sbg:modifiedOn: 1629513122
+sbg:project: smgogarten/genesis-relatedness-pre-build
+sbg:projectName: GENESIS relatedness - Pre-build
+sbg:publisher: sbg
+sbg:revision: 7
+sbg:revisionNotes: |-
+  Uploaded using sbpack v2020.10.05. 
+  Source: 
+  repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+  file: relatedness/tools/kinship_plots.cwl
+  commit: f23d6de
+sbg:revisionsInfo:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451320
+  sbg:revision: 0
+  sbg:revisionNotes:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451341
+  sbg:revision: 1
+  sbg:revisionNotes: import to pre-build project
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623444403
+  sbg:revision: 2
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: 878723c
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623444726
+  sbg:revision: 3
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623445046
+  sbg:revision: 4
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623450748
+  sbg:revision: 5
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623740865
+  sbg:revision: 6
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: 6d87792
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1629513122
+  sbg:revision: 7
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: relatedness/tools/kinship_plots.cwl
+    commit: f23d6de
+sbg:sbgMaintained: false
+sbg:validationErrors: []

--- a/relatedness/tools/pcrelate.cwl
+++ b/relatedness/tools/pcrelate.cwl
@@ -70,25 +70,33 @@ inputs:
 - id: n_pcs
   label: Number of PCs
   doc: Number of PCs to use in adjusting for ancestry.
-  type: int?
+  type:
+  - 'null'
+  - int
   sbg:category: Input Options
   sbg:toolDefaultValue: '3'
 - id: out_prefix
   label: Output prefix
   doc: Prefix for output files.
-  type: string?
+  type:
+  - 'null'
+  - string
   sbg:category: Input Options
   sbg:toolDefaultValue: pcrelate
 - id: variant_include_file
   label: Variant include file
   doc: |-
     RData file with vector of variant.id to include. If not provided, all variants in the GDS file are included.
-  type: File?
+  type:
+  - 'null'
+  - File
   sbg:category: Input Files
 - id: variant_block_size
   label: Variant block size
   doc: Number of variants to read in a single block.
-  type: int?
+  type:
+  - 'null'
+  - int
   default: 1024
   sbg:category: Input Options
   sbg:toolDefaultValue: '1024'
@@ -96,14 +104,18 @@ inputs:
   label: Sample Include file
   doc: |-
     RData file with vector of sample.id to include. If not provided, all samples in the GDS file are included.
-  type: File?
+  type:
+  - 'null'
+  - File
   sbg:category: Input Files
   sbg:fileTypes: RDATA
 - id: n_sample_blocks
   label: Number of sample blocks
   doc: |-
     Number of blocks to divide samples into for parallel computation. Adjust depending on computer memory and number of samples in the analysis.
-  type: int?
+  type:
+  - 'null'
+  - int
   default: 1
   sbg:category: Input Options
   sbg:toolDefaultValue: '1'
@@ -111,7 +123,9 @@ inputs:
   label: Sample block combination
   doc: |-
     If number of sample blocks is > 1, run on this combination of sample blocks. Allowed values are 1:N where N is the number of possible combinations of sample blocks [i, j].
-  type: int?
+  type:
+  - 'null'
+  - int
   default: 1
   sbg:category: Input Options
   sbg:toolDefaultValue: '1'
@@ -119,7 +133,9 @@ inputs:
   label: Return IBD probabilities?
   doc: |-
     Set this to FALSE to skip computing pairwise IBD probabilities (k0, k1, k2). If FALSE, the plottng step is also skipped, as it requires values for k0.
-  type: boolean?
+  type:
+  - 'null'
+  - boolean
   sbg:category: Input Options
   sbg:toolDefaultValue: 'TRUE'
 
@@ -127,7 +143,9 @@ outputs:
 - id: pcrelate
   label: PC-Relate results
   doc: RData files with PC-Relate results for each sample block.
-  type: File?
+  type:
+  - 'null'
+  - File
   outputBinding:
     glob: '*.RData'
   sbg:fileTypes: RDATA
@@ -154,3 +172,47 @@ hints:
   value: job.out.log
 - class: sbg:SaveLogs
   value: pcrelate.config
+id: |-
+  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/genesis-relatedness-pre-build/pcrelate/2/raw/
+sbg:appVersion:
+- v1.2
+sbg:content_hash: a72bf7d96b4bc1d48e7485a9f90ed1e593edc3fd258ffa279797130eb6f102ba2
+sbg:contributors:
+- smgogarten
+sbg:createdBy: smgogarten
+sbg:createdOn: 1609451776
+sbg:id: smgogarten/genesis-relatedness-pre-build/pcrelate/2
+sbg:image_url:
+sbg:latestRevision: 2
+sbg:modifiedBy: smgogarten
+sbg:modifiedOn: 1623740858
+sbg:project: smgogarten/genesis-relatedness-pre-build
+sbg:projectName: GENESIS relatedness - Pre-build
+sbg:publisher: sbg
+sbg:revision: 2
+sbg:revisionNotes: |-
+  Uploaded using sbpack v2020.10.05. 
+  Source: 
+  repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+  file: 
+  commit: 6d87792
+sbg:revisionsInfo:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451776
+  sbg:revision: 0
+  sbg:revisionNotes:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451801
+  sbg:revision: 1
+  sbg:revisionNotes: import to pre-build project
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623740858
+  sbg:revision: 2
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: 6d87792
+sbg:sbgMaintained: false
+sbg:validationErrors: []

--- a/relatedness/tools/pcrelate_beta.cwl
+++ b/relatedness/tools/pcrelate_beta.cwl
@@ -57,33 +57,43 @@ inputs:
 - id: n_pcs
   label: Number of PCs
   doc: Number of PCs (Principal Components) to use in adjusting for ancestry.
-  type: int?
+  type:
+  - 'null'
+  - int
   default: 3
   sbg:category: Input Options
   sbg:toolDefaultValue: '3'
 - id: out_prefix
   label: Output prefix
   doc: Prefix for output files.
-  type: string?
+  type:
+  - 'null'
+  - string
   sbg:category: Input Options
 - id: sample_include_file
   label: Sample Include file
   doc: |-
     RData file with vector of sample.id to include. If not provided, all samples in the GDS file are included.
-  type: File?
+  type:
+  - 'null'
+  - File
   sbg:category: Input Files
   sbg:fileTypes: RDATA
 - id: variant_include_file
   label: Variant include file
   doc: |-
     RData file with vector of variant.id to include. If not provided, all variants in the GDS file are included.
-  type: File?
+  type:
+  - 'null'
+  - File
   sbg:category: Input Options
   sbg:fileTypes: RDATA
 - id: variant_block_size
   label: Variant block size
   doc: Number of variants to read in a single block.
-  type: int?
+  type:
+  - 'null'
+  - int
   default: 1024
   sbg:category: Input Options
   sbg:toolDefaultValue: '1024'
@@ -92,7 +102,9 @@ outputs:
 - id: beta
   label: ISAF beta values
   doc: RData file with ISAF beta values
-  type: File?
+  type:
+  - 'null'
+  - File
   outputBinding:
     glob: '*.RData'
   sbg:fileTypes: RDATA
@@ -115,3 +127,47 @@ hints:
   value: job.out.log
 - class: sbg:SaveLogs
   value: pcrelate_beta.config
+id: |-
+  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/genesis-relatedness-pre-build/pcrelate-beta/2/raw/
+sbg:appVersion:
+- v1.2
+sbg:content_hash: a341c5bc99c5c0660ea4305d3a5e792271d1c394df734dcc30e5fad9d7943a8d5
+sbg:contributors:
+- smgogarten
+sbg:createdBy: smgogarten
+sbg:createdOn: 1609451825
+sbg:id: smgogarten/genesis-relatedness-pre-build/pcrelate-beta/2
+sbg:image_url:
+sbg:latestRevision: 2
+sbg:modifiedBy: smgogarten
+sbg:modifiedOn: 1623740854
+sbg:project: smgogarten/genesis-relatedness-pre-build
+sbg:projectName: GENESIS relatedness - Pre-build
+sbg:publisher: sbg
+sbg:revision: 2
+sbg:revisionNotes: |-
+  Uploaded using sbpack v2020.10.05. 
+  Source: 
+  repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+  file: 
+  commit: 6d87792
+sbg:revisionsInfo:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451825
+  sbg:revision: 0
+  sbg:revisionNotes:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451844
+  sbg:revision: 1
+  sbg:revisionNotes: import to pre-build project
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623740854
+  sbg:revision: 2
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: 6d87792
+sbg:sbgMaintained: false
+sbg:validationErrors: []

--- a/relatedness/tools/pcrelate_correct.cwl
+++ b/relatedness/tools/pcrelate_correct.cwl
@@ -43,14 +43,18 @@ inputs:
 - id: pcrelate_block_files
   label: PCRelate files for all sample blocks
   doc: PCRelate files for all sample blocks
-  type: File[]
+  type:
+    type: array
+    items: File
   sbg:category: Input Files
   sbg:fileTypes: RDATA
 - id: sparse_threshold
   label: Sparse threshold
   doc: |-
     Threshold for making the output kinship matrix sparse. A block diagonal matrix will be created such that any pair of samples with a kinship estimate greater than the threshold is in the same block; all pairwise estimates within a block are kept, and pairwise estimates between blocks are set to 0.
-  type: float?
+  type:
+  - 'null'
+  - float
   default: 0.02209709
   sbg:category: Input Options
   sbg:toolDefaultValue: 2^(-11/2) (~0.022, 4th degree)
@@ -59,7 +63,9 @@ outputs:
 - id: pcrelate_output
   label: PC-Relate output file
   doc: PC-Relate output file with all samples
-  type: File?
+  type:
+  - 'null'
+  - File
   outputBinding:
     glob: '*_pcrelate.RData'
   sbg:fileTypes: RDATA
@@ -67,7 +73,9 @@ outputs:
   label: Kinship matrix
   doc: |-
     A block diagonal matrix of pairwise kinship estimates with sparsity set by sparse_threshold. Samples are clustered into blocks of relatives based on `sparse_threshold`; all kinship estimates within a block are kept, and kinship estimates between blocks are set to 0. When `sparse_threshold` is 0, this is a dense matrix with all pairwise kinship estimates.
-  type: File?
+  type:
+  - 'null'
+  - File
   outputBinding:
     glob: '*_pcrelate_Matrix.RData'
   sbg:fileTypes: RDATA
@@ -105,3 +113,47 @@ hints:
   value: job.out.log
 - class: sbg:SaveLogs
   value: pcrelate_correct.config
+id: |-
+  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/genesis-relatedness-pre-build/pcrelate-correct/2/raw/
+sbg:appVersion:
+- v1.2
+sbg:content_hash: af4cd928c332332da31020081a18ba26d12d920c77c9cfe04d7e4cefd3e702cf1
+sbg:contributors:
+- smgogarten
+sbg:createdBy: smgogarten
+sbg:createdOn: 1609451869
+sbg:id: smgogarten/genesis-relatedness-pre-build/pcrelate-correct/2
+sbg:image_url:
+sbg:latestRevision: 2
+sbg:modifiedBy: smgogarten
+sbg:modifiedOn: 1623740859
+sbg:project: smgogarten/genesis-relatedness-pre-build
+sbg:projectName: GENESIS relatedness - Pre-build
+sbg:publisher: sbg
+sbg:revision: 2
+sbg:revisionNotes: |-
+  Uploaded using sbpack v2020.10.05. 
+  Source: 
+  repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+  file: 
+  commit: 6d87792
+sbg:revisionsInfo:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451869
+  sbg:revision: 0
+  sbg:revisionNotes:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451892
+  sbg:revision: 1
+  sbg:revisionNotes: import to pre-build project
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623740859
+  sbg:revision: 2
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: 6d87792
+sbg:sbgMaintained: false
+sbg:validationErrors: []

--- a/relatedness/tools/plink_make_bed.cwl
+++ b/relatedness/tools/plink_make_bed.cwl
@@ -94,3 +94,65 @@ arguments:
 hints:
 - class: sbg:SaveLogs
   value: job.out.log
+id: |-
+  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/genesis-relatedness-pre-build/plink-make-bed/4/raw/
+sbg:appVersion:
+- v1.2
+sbg:content_hash: addfad77655567300c74ccb994be41549ec8e54a4571c3cc153bfba9c5cfbc61c
+sbg:contributors:
+- smgogarten
+sbg:createdBy: smgogarten
+sbg:createdOn: 1609451922
+sbg:id: smgogarten/genesis-relatedness-pre-build/plink-make-bed/4
+sbg:image_url:
+sbg:latestRevision: 4
+sbg:modifiedBy: smgogarten
+sbg:modifiedOn: 1623450741
+sbg:project: smgogarten/genesis-relatedness-pre-build
+sbg:projectName: GENESIS relatedness - Pre-build
+sbg:publisher: sbg
+sbg:revision: 4
+sbg:revisionNotes: |-
+  Uploaded using sbpack v2020.10.05. 
+  Source: 
+  repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+  file: 
+  commit: c9c8b8d
+sbg:revisionsInfo:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451922
+  sbg:revision: 0
+  sbg:revisionNotes:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451941
+  sbg:revision: 1
+  sbg:revisionNotes: import to pre-build project
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623444723
+  sbg:revision: 2
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623445038
+  sbg:revision: 3
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623450741
+  sbg:revision: 4
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: c9c8b8d
+sbg:sbgMaintained: false
+sbg:validationErrors: []

--- a/relatedness/tools/sample_blocks_to_segments.cwl
+++ b/relatedness/tools/sample_blocks_to_segments.cwl
@@ -12,14 +12,19 @@ inputs:
   label: Number of sample blocks
   doc: |-
     Number of blocks to divide samples into for parallel computation. Adjust depending on computer memory and number of samples in the analysis.
-  type: int?
+  type:
+  - 'null'
+  - int
   default: 1
   sbg:category: Input Options
   sbg:toolDefaultValue: '1'
 
 outputs:
 - id: segments
-  type: int[]?
+  type:
+  - 'null'
+  - type: array
+    items: int
   outputBinding:
     outputEval: |-
       ${ 
@@ -39,3 +44,47 @@ outputs:
       }
 
 baseCommand: []
+id: |-
+  https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2/apps/smgogarten/genesis-relatedness-pre-build/sample-blocks-to-segments/2/raw/
+sbg:appVersion:
+- v1.2
+sbg:content_hash: a7be306a45f3d66a0c82a476413df91fbce288099db016d6acb3c435ebc96e015
+sbg:contributors:
+- smgogarten
+sbg:createdBy: smgogarten
+sbg:createdOn: 1609451972
+sbg:id: smgogarten/genesis-relatedness-pre-build/sample-blocks-to-segments/2
+sbg:image_url:
+sbg:latestRevision: 2
+sbg:modifiedBy: smgogarten
+sbg:modifiedOn: 1623740857
+sbg:project: smgogarten/genesis-relatedness-pre-build
+sbg:projectName: GENESIS relatedness - Pre-build
+sbg:publisher: sbg
+sbg:revision: 2
+sbg:revisionNotes: |-
+  Uploaded using sbpack v2020.10.05. 
+  Source: 
+  repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+  file: 
+  commit: 6d87792
+sbg:revisionsInfo:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451972
+  sbg:revision: 0
+  sbg:revisionNotes:
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1609451996
+  sbg:revision: 1
+  sbg:revisionNotes: import to pre-build project
+- sbg:modifiedBy: smgogarten
+  sbg:modifiedOn: 1623740857
+  sbg:revision: 2
+  sbg:revisionNotes: |-
+    Uploaded using sbpack v2020.10.05. 
+    Source: 
+    repo: git@github.com:UW-GAC/analysis_pipeline_cwl.git
+    file: 
+    commit: 6d87792
+sbg:sbgMaintained: false
+sbg:validationErrors: []


### PR DESCRIPTION
 assoc-aggregate:
* sbg_gds_renamer now CWL 1.2, uses 2.10.0 of docker image, and adds chmod -R 777 to its output
* Azure hints

The other two are mostly equivalent; see specific commits.

Only covers assoc-aggregate, king-ibseg, and pc-relate as those are the ones UCSC are currently looking at.